### PR TITLE
Add logic to load the previous log after a refresh

### DIFF
--- a/files/usr/local/www/zeek_alerts.php
+++ b/files/usr/local/www/zeek_alerts.php
@@ -113,17 +113,23 @@ $( "#logfile" ).change(function() {
 });
 
 function updateSelect() {
-	var x = 'x='+$('#logfile').length;
-	jQuery.ajax({
-		type: "POST",
-		url: "select_box_file.php",
-		data: x,
-		success: function(html) {
-			if (html) {
-				$("#logfile").html(html);
-			}
-		},
-	});
+        var selected = $('#logfile').val();
+
+        var x = 'x='+$('#logfile').length;
+        jQuery.ajax({
+                type: "POST",
+                url: "select_box_file.php",
+                data: x,
+                success: function(html) {
+                        if (html) {
+                                $("#logfile").html(html);
+
+                                if (selected != 0 && selected != null && selected != undefined) {
+                                        $('#logfile').val(selected);
+                                }
+                        }
+                },
+        });
 }
 
 function showLog(content, url, program) {

--- a/files/usr/local/www/zeek_alerts.php
+++ b/files/usr/local/www/zeek_alerts.php
@@ -124,7 +124,7 @@ function updateSelect() {
 			if (html) {
 				$("#logfile").html(html);
 
-				if (selected != 0 && selected != null && selected != undefined) {
+				if (selected != undefined && selected) {
 					$('#logfile').val(selected);
 				}
 			}

--- a/files/usr/local/www/zeek_alerts.php
+++ b/files/usr/local/www/zeek_alerts.php
@@ -124,7 +124,7 @@ function updateSelect() {
 			if (html) {
 				$("#logfile").html(html);
 
-				if (selected != undefined && selected) {
+				if (typeof selected !== undefined && selected) {
 					$('#logfile').val(selected);
 				}
 			}

--- a/files/usr/local/www/zeek_alerts.php
+++ b/files/usr/local/www/zeek_alerts.php
@@ -113,23 +113,23 @@ $( "#logfile" ).change(function() {
 });
 
 function updateSelect() {
-        var selected = $('#logfile').val();
+	var selected = $('#logfile').val();
 
-        var x = 'x='+$('#logfile').length;
-        jQuery.ajax({
-                type: "POST",
-                url: "select_box_file.php",
-                data: x,
-                success: function(html) {
-                        if (html) {
-                                $("#logfile").html(html);
+	var x = 'x='+$('#logfile').length;
+	jQuery.ajax({
+		type: "POST",
+		url: "select_box_file.php",
+		data: x,
+		success: function(html) {
+			if (html) {
+				$("#logfile").html(html);
 
-                                if (selected != 0 && selected != null && selected != undefined) {
-                                        $('#logfile').val(selected);
-                                }
-                        }
-                },
-        });
+				if (selected != 0 && selected != null && selected != undefined) {
+					$('#logfile').val(selected);
+				}
+			}
+		},
+	});
 }
 
 function showLog(content, url, program) {


### PR DESCRIPTION
Log kept reverting to stdout.log, this should keep the previous log on the realtime display. There is a possibility that a non-existent log is selected if rolled over and doesn't immediately exist, but this behavior is better than always going back to stdout.log after two refreshes.